### PR TITLE
Add audioop-lts for Python 3.13+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 python-dotenv
 dataset
 uwuipy
+audioop-lts; python_version>='3.13'


### PR DESCRIPTION
Simple fix for the bot not being able to be deployed on Python 3.13.