### PR TITLE
New features for astral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,4 @@
 **/__pycache__/
 *.py[cod]
 *$py.class
-*.db
-*.db-shm
-*.db-wal
+astral.ini

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.py[cod]
 *$py.class
 astral.ini
+storage/* 
+!storage/example.ini

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 astral.ini
 storage/* 
 !storage/example.ini
+venv*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Eva's J773gAP - Remote Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "192.168.69.3",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}

--- a/astral.example.ini
+++ b/astral.example.ini
@@ -1,12 +1,32 @@
 [astral]
-;; The name of the bot. You can change it here if you'd like.
-name   = astral
-;; The bot token used to connect to Discord's gateway.
+;; Name of the bot. You can change it here if you'd like.
+name      = astral
+;; Whether or not to run the bot in debug mode.
+;; This can (and will) be overridden by adding a debug
+;; value to specific cogs.
+debug     = false
+;; Bot token used to connect to Discord's gateway.
 ;; You can get one from https://discord.com/developers.
-token  = your-token-here
-;; The user ID (or IDs) for the bot's owner for owner-only commands.
+token     = your-token-here
+;; User ID (or IDs) for the bot's owner for owner-only commands.
 ;; Comma-separated. In the future, a command will be available to add 
 ;; and remove owners.
-owners = bot-owner-id
-;; The cogs to load. Comma-separated. Type "all" to load all cogs.
-cogs   = osuUtils, fun, lookupUtils
+owners    = bot-owner-id
+;; Cogs to load. Comma-separated. Type "all" to load all cogs.
+cogs      = osuUtils, fun, lookupUtils
+
+;; Configurations used for the ESC/POS functionality of astral.
+[escpos]
+;; IP address and port used to connect to the printer over the network. 
+;; astral doesn't support other methods of connecting to ESC/POS machines
+;; at this time.
+ip        = 192.168.69.56
+port      = 9100
+;; Printer profile to use when printing from astral.
+profile   = TM-T88V
+;; Enables the option to print with multitone support instead of dithering 
+;; for images.
+multitone = true
+;; Enables more advanced message editing for current tasks on Discord instead
+;; of sitting at "<bot> is thinking..."
+verbosity = true

--- a/astral.example.ini
+++ b/astral.example.ini
@@ -1,0 +1,12 @@
+[astral]
+;; The name of the bot. You can change it here if you'd like.
+name   = astral
+;; The bot token used to connect to Discord's gateway.
+;; You can get one from https://discord.com/developers.
+token  = your-token-here
+;; The user ID (or IDs) for the bot's owner for owner-only commands.
+;; Comma-separated. In the future, a command will be available to add 
+;; and remove owners.
+owners = bot-owner-id
+;; The cogs to load. Comma-separated. Type "all" to load all cogs.
+cogs   = osuUtils, fun, lookupUtils

--- a/astral.example.ini
+++ b/astral.example.ini
@@ -1,32 +1,33 @@
 [astral]
 ;; Name of the bot. You can change it here if you'd like.
-name      = astral
+name          = astral
 ;; Whether or not to run the bot in debug mode.
 ;; This can (and will) be overridden by adding a debug
 ;; value to specific cogs.
-debug     = false
+debug         = false
 ;; Bot token used to connect to Discord's gateway.
 ;; You can get one from https://discord.com/developers.
-token     = your-token-here
+token         = your-token-here
 ;; User ID (or IDs) for the bot's owner for owner-only commands.
 ;; Comma-separated. In the future, a command will be available to add 
 ;; and remove owners.
-owners    = bot-owner-id
+owners        = bot-owner-id
 ;; Cogs to load. Comma-separated. Type "all" to load all cogs.
-cogs      = osuUtils, fun, lookupUtils
-
+cogs          = osuUtils, fun, lookupUtils
+;; The auto-saving interval.
+save_interval = 60
 ;; Configurations used for the ESC/POS functionality of astral.
 [escpos]
 ;; IP address and port used to connect to the printer over the network. 
 ;; astral doesn't support other methods of connecting to ESC/POS machines
 ;; at this time.
-ip        = 192.168.69.56
-port      = 9100
+ip            = 192.168.69.56
+port          = 9100
 ;; Printer profile to use when printing from astral.
-profile   = TM-T88V
+profile       = TM-T88V
 ;; Enables the option to print with multitone support instead of dithering 
 ;; for images.
-multitone = true
+multitone     = true
 ;; Enables more advanced message editing for current tasks on Discord instead
 ;; of sitting at "<bot> is thinking..."
-verbosity = true
+verbosity     = true

--- a/astral.py
+++ b/astral.py
@@ -2,16 +2,18 @@
 import discord
 import os
 from discord.ext import commands, tasks
-from support.storage import astralStorage
-
-print(f"[bot    ] {astralStorage.getGlobalStr("astral", "name")}")
+from support.storage import astral_storage
+from support.error import astral_error, astral_exception
+print(f"[bot    ] {astral_storage.get_global_str("astral", "name")}")
 
 # console markers
 success = '[√]'
 error = '[x]'
 
 #load token and owner from disk
-token = astralStorage.getGlobalStr("astral", "token")
+token = astral_storage.get_global_str("astral", "token")
+if token is None:
+    raise astral_exception(astral_error.bot.undef_token)
 
 # bot setup
 intents = discord.Intents.default()
@@ -33,7 +35,7 @@ bot = commands.Bot(
 )
 
 #load cogs
-cogs = astralStorage.getGlobalStrList("astral", "cogs")
+cogs = astral_storage.get_global_str_list("astral", "cogs")
 if cogs is None:
     cogs = ['osuUtils', 'fun', 'lookupUtils']
 if "all" in cogs:
@@ -45,12 +47,12 @@ for cog in cogs:
     print(f"[bot    ] loading cog {cog}")
     bot.load_extension(f'cogs.{cog}')
 
-@tasks.loop(seconds=astralStorage.getGlobalInt("astral", "saveInterval"))
+@tasks.loop(seconds=astral_storage.get_global_int("astral", "saveInterval"))
 async def autosave():
     print("[storage] saving all configs to disk")
     try:
-        astralStorage.saveConfigsToDisk()
-        print(f"[storage] saved. waiting another {astralStorage.getGlobalInt("astral", "saveInterval")} seconds before saving again.")
+        astral_storage.save_configs_to_disk()
+        print(f"[storage] saved. waiting another {astral_storage.get_global_int("astral", "saveInterval")} seconds before saving again.")
     except Exception as e:
         print(e)
 

--- a/astral.py
+++ b/astral.py
@@ -1,25 +1,39 @@
-from support.storage import astralStorage
+
 import discord
 import os
-from discord.ext import commands
+from discord.ext import commands, tasks
+from support.storage import astralStorage
 
-print(f"[bot    ] {astralStorage.getGlobalOption("name")}")
+print(f"[bot    ] {astralStorage.getGlobalStr("astral", "name")}")
 
 # console markers
 success = '[√]'
 error = '[x]'
 
 #load token and owner from disk
-token = astralStorage.getGlobalOption("token")
+token = astralStorage.getGlobalStr("astral", "token")
 
 # bot setup
 intents = discord.Intents.default()
 intents.members = True
 
-bot = commands.Bot(intents=intents)
+# For safety reasons, all pings are disabled by default.
+# In the future, this will be configurable via .ini, for
+# now you can override this per-message.
+allowed_mentions = discord.AllowedMentions(
+    everyone=False, 
+    users=False, 
+    roles=False, 
+    replied_user=False
+)
+
+bot = commands.Bot(
+    intents=intents,
+    allowed_mentions=allowed_mentions
+)
 
 #load cogs
-cogs = list(map(str.strip, astralStorage.getGlobalOption("cogs").split(",")))
+cogs = astralStorage.getGlobalStrList("astral", "cogs")
 if cogs is None:
     cogs = ['osuUtils', 'fun', 'lookupUtils']
 if "all" in cogs:
@@ -31,8 +45,27 @@ for cog in cogs:
     print(f"[bot    ] loading cog {cog}")
     bot.load_extension(f'cogs.{cog}')
 
+@tasks.loop(seconds=astralStorage.getGlobalInt("astral", "saveInterval"))
+async def autosave():
+    print("[storage] saving all configs to disk")
+    try:
+        astralStorage.saveConfigsToDisk()
+        print(f"[storage] saved. waiting another {astralStorage.getGlobalInt("astral", "saveInterval")} seconds before saving again.")
+    except Exception as e:
+        print(e)
+
 @bot.event
 async def on_ready():
     print(f"[bot    ] {success} Bot sucessfully initialized as {bot.user}")
+    autosave.start()
+
+@bot.event
+async def on_application_command_error(ctx: discord.ApplicationContext, error: discord.DiscordException):
+    if isinstance(error, commands.CommandOnCooldown):
+        await ctx.respond("The used command is currently on cooldown!")
+    elif isinstance(error, commands.MissingRole):
+        await ctx.respond("You don't have the required role to use this command")
+    else:
+        raise error  # Here we raise other errors to ensure they aren't ignored
 
 bot.run(token)

--- a/astral.py
+++ b/astral.py
@@ -1,21 +1,18 @@
+from support.storage import astralStorage
 import discord
-import requests
-import dotenv
-import sqlite3
 import os
-from requests.exceptions import HTTPError
 from discord.ext import commands
 
-print(f"astral")
+storage = astralStorage
+
+print(f"[bot    ] {storage.getGlobalOption("name")}")
 
 # console markers
 success = '[√]'
 error = '[x]'
 
 #load token and owner from disk
-dotenv.load_dotenv()
-token = str(os.getenv("TOKEN"))
-ownerid = str(os.getenv("OWNERID"))
+token = storage.getGlobalOption("token")
 
 # bot setup
 intents = discord.Intents.default()
@@ -24,12 +21,20 @@ intents.members = True
 bot = commands.Bot(intents=intents)
 
 #load cogs
-cogs_list = ['osuUtils', 'fun', 'lookupUtils']
-for cog in cogs_list:
+cogs = list(map(str.strip, storage.getGlobalOption("cogs").split(",")))
+if cogs is None:
+    cogs = ['osuUtils', 'fun', 'lookupUtils']
+if "all" in cogs:
+    cogs = os.listdir("cogs")
+    for file in cogs:
+        if ".py" not in file:
+            cogs.remove(file) 
+for cog in cogs:
+    print(f"[bot    ] loading cog {cog}")
     bot.load_extension(f'cogs.{cog}')
 
 @bot.event
 async def on_ready():
-    print(f"{success} Bot sucessfully initialized as {bot.user}")
+    print(f"[bot    ] {success} Bot sucessfully initialized as {bot.user}")
 
 bot.run(token)

--- a/astral.py
+++ b/astral.py
@@ -3,16 +3,14 @@ import discord
 import os
 from discord.ext import commands
 
-storage = astralStorage
-
-print(f"[bot    ] {storage.getGlobalOption("name")}")
+print(f"[bot    ] {astralStorage.getGlobalOption("name")}")
 
 # console markers
 success = '[√]'
 error = '[x]'
 
 #load token and owner from disk
-token = storage.getGlobalOption("token")
+token = astralStorage.getGlobalOption("token")
 
 # bot setup
 intents = discord.Intents.default()
@@ -21,7 +19,7 @@ intents.members = True
 bot = commands.Bot(intents=intents)
 
 #load cogs
-cogs = list(map(str.strip, storage.getGlobalOption("cogs").split(",")))
+cogs = list(map(str.strip, astralStorage.getGlobalOption("cogs").split(",")))
 if cogs is None:
     cogs = ['osuUtils', 'fun', 'lookupUtils']
 if "all" in cogs:

--- a/astral.py
+++ b/astral.py
@@ -3,6 +3,7 @@ import discord
 import os
 from discord.ext import commands, tasks
 from support.storage import astral_storage
+from support.autosave import _start as start_autosave, _update as update_autosave
 from support.error import astral_error, astral_exception
 print(f"[bot    ] {astral_storage.get_global_str("astral", "name")}")
 
@@ -47,19 +48,10 @@ for cog in cogs:
     print(f"[bot    ] loading cog {cog}")
     bot.load_extension(f'cogs.{cog}')
 
-@tasks.loop(seconds=astral_storage.get_global_int("astral", "saveInterval"))
-async def autosave():
-    print("[storage] saving all configs to disk")
-    try:
-        astral_storage.save_configs_to_disk()
-        print(f"[storage] saved. waiting another {astral_storage.get_global_int("astral", "saveInterval")} seconds before saving again.")
-    except Exception as e:
-        print(e)
-
 @bot.event
 async def on_ready():
     print(f"[bot    ] {success} Bot sucessfully initialized as {bot.user}")
-    autosave.start()
+    start_autosave()
 
 @bot.event
 async def on_application_command_error(ctx: discord.ApplicationContext, error: discord.DiscordException):

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -4,7 +4,7 @@ from requests.exceptions import HTTPError
 from discord import option
 from discord.commands import SlashCommandGroup, OptionChoice
 from discord.ext import commands
-from support.storage import astralStorage
+from support.storage import astral_storage
 
 class config(commands.Cog):
     def __init__(self, bot):
@@ -21,14 +21,14 @@ class config(commands.Cog):
     async def saveAll(self, ctx):
         try:
             msg = await ctx.respond("Preparing to save data, please do not remove MEMORY CARD™ for PLAYSTATION®2...")
-            if (not astralStorage.isCallerOwner(ctx.author)):
+            if (not astral_storage.is_caller_owner(ctx.author)):
                 await msg.edit(content="You don't have permission to do that.")
             
-            astralStorage.saveConfigsToDisk()
+            astral_storage.saveConfigsToDisk()
             await msg.edit(content="Saved to MEMORY CARD™ for PLAYSTATION®2 in slot 1.")
         except Exception as e:
             content = "Something went wrong while running that command."
-            if astralStorage.getGlobalBool("astral", "debug"):
+            if astral_storage.get_global_bool("astral", "debug"):
                 print("[command] roletest failed: {e}")
                 content += f"\n{e}"
             await msg.edit(content=content)
@@ -47,7 +47,7 @@ class config(commands.Cog):
     async def addOwner(self, ctx, operation: str, user: discord.Member):
         try:
             msg = await ctx.respond(f"Preparing to add {user.mention} as an owner...")
-            owners = astralStorage.getGlobalIntList("astral", "owners")
+            owners = astral_storage.get_global_int_list("astral", "owners")
             if ctx.author.id not in owners and len(owners) > 0:
                 await msg.edit(content="You don't have permission to do that.")
                 return
@@ -64,11 +64,11 @@ class config(commands.Cog):
                 return
             
             owners.append(user.id)
-            astralStorage.setGlobalList("astral", "owners", owners)
-            await msg.edit(content=f"Added ***{user.mention}*** as an owner for {astralStorage.getGlobalStr("astral", "name")}.")
+            astral_storage.set_global_list("astral", "owners", owners)
+            await msg.edit(content=f"Added ***{user.mention}*** as an owner for {astral_storage.get_global_str("astral", "name")}.")
         except Exception as e:
             msg = "Something went wrong while running that command."
-            if astralStorage.getGlobalBool("debug"):
+            if astral_storage.get_global_bool("debug"):
                 print("[command] addOwner failed: {e}")
                 msg += f"\n{e}"
             await msg.edit(content=msg)
@@ -82,49 +82,49 @@ class config(commands.Cog):
     async def configureEscpos(self, ctx, ip: str = None, port: int = None, profile: str = None, multitone: bool = None, verbosity: bool = None):
         try:
             msg = await ctx.respond("Configuring ESC/POS functionality...")
-            if (not astralStorage.isCallerOwner(ctx.author)):
+            if (not astral_storage.is_caller_owner(ctx.author)):
                 await msg.edit(content="You don't have permission to do that.")
             
             content = ""
             if ip is not None:
-                val = astralStorage.getGlobalStr("escpos", "ip")
+                val = astral_storage.get_global_str("escpos", "ip")
                 if val is not None and ip == val:
                     content += f"IP address remains set to {ip}\n"
                 else:
-                    astralStorage.setGlobalStr("escpos", "ip", ip)
+                    astral_storage.set_global_str("escpos", "ip", ip)
                     content += f"IP address has been set to {ip}\n"
             if port is not None:
-                val = astralStorage.getGlobalStr("escpos", "port")
+                val = astral_storage.get_global_str("escpos", "port")
                 if val is not None and port == val:
                     content += f"Port remains set to {ip}\n"
                 else:
-                    astralStorage.setGlobalInt("escpos", "port", port)
+                    astral_storage.set_global_int("escpos", "port", port)
                     content += f"Port has been set to {port}\n"
             if profile is not None:
-                val = astralStorage.getGlobalStr("escpos", "profile")
+                val = astral_storage.get_global_str("escpos", "profile")
                 if val is not None and profile == val:
                     content += f"Profile remains set to {ip}\n"
                 else:
-                    astralStorage.setGlobalStr("escpos", "profile", profile)
+                    astral_storage.set_global_str("escpos", "profile", profile)
                     content += f"Profile has been set to {profile}\n"
             if multitone is not None:
-                val = astralStorage.getGlobalStr("escpos", "multitone")
+                val = astral_storage.get_global_str("escpos", "multitone")
                 if val is not None and multitone == val:
                     content += f"Multitone remains {"enabled" if multitone else "disabled"}\n"
                 else:
-                    astralStorage.setGlobalBool("escpos", "multitone", multitone)
+                    astral_storage.set_global_bool("escpos", "multitone", multitone)
                     content += f"Multitone is {"enabled" if multitone else "disabled"}\n"
             if verbosity is not None:
-                val = astralStorage.getGlobalStr("escpos", "verbosity")
+                val = astral_storage.get_global_str("escpos", "verbosity")
                 if val is not None and verbosity == val:
                     content += f"Discord verbosity remains set to {ip}\n"
                 else:
-                    astralStorage.setGlobalBool("escpos", "verbosity", verbosity)
+                    astral_storage.set_global_bool("escpos", "verbosity", verbosity)
                     content += f"Discord verbosity {"enabled" if multitone else "disabled"}\n"
             await msg.edit(content=f"{content}\nYour changes have been saved.")
         except Exception as e:
             content = "Something went wrong while running that command."
-            if astralStorage.getGlobalBool("astral", "debug"):
+            if astral_storage.get_global_bool("astral", "debug"):
                 print("[command] roletest failed: {e}")
                 content += f"\n{e}"
             await msg.edit(content=content)
@@ -141,7 +141,7 @@ class config(commands.Cog):
     @option("role", type=discord.Role, description="The role to act upon", required=False)
     async def escposRolesFromServer(self, ctx, operation: str = None, role: discord.Role = None): 
         try:
-            roles = astralStorage.getServerIntList(ctx.guild.id, "allowedroles", "escpos")
+            roles = astral_storage.get_server_int_list(ctx.guild.id, "allowedroles", "escpos")
             if roles is None: roles = []
             if operation is None and role is None:
                 msg = await ctx.respond("Getting ESC/POS roles...")
@@ -167,7 +167,7 @@ class config(commands.Cog):
 
 
             msg = await ctx.respond(f"Preparing to {operation} {role.mention} to escpos roles...")
-            if (not astralStorage.isCallerOwner(ctx.author)):
+            if (not astral_storage.is_caller_owner(ctx.author)):
                 await msg.edit(content="You don't have permission to do that.")
             
             if role.id in roles and operation == "add":
@@ -180,11 +180,11 @@ class config(commands.Cog):
 
             if operation == "add":    roles.append(role.id)
             if operation == "remove": roles.remove(role.id)
-            astralStorage.setServerList(ctx.guild.id, "allowedroles", "escpos", roles)
+            astral_storage.set_server_list(ctx.guild.id, "allowedroles", "escpos", roles)
             await msg.edit(content=f"Users with ***{role.mention}*** can {"now" if operation == "add" else "no longer"} interact with the ESC/POS printer.")
         except Exception as e:
             content = "Something went wrong while running that command."
-            if astralStorage.getGlobalBool("astral", "debug"):
+            if astral_storage.get_global_bool("astral", "debug"):
                 print("[command] escposRolesFromServer failed: {e}")
                 content += f"\n{e}"
             await msg.edit(content=content)

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -1,0 +1,196 @@
+import discord
+import requests
+from requests.exceptions import HTTPError
+from discord import option
+from discord.commands import SlashCommandGroup, OptionChoice
+from discord.ext import commands
+from support.storage import astralStorage
+
+class config(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    # Config group commands
+    configGroup = SlashCommandGroup("config", "Utilities related to configuring the bot")
+
+    ## Allows saving all configurations in memory to disk before the next scheduled autosave.
+    ## Doesn't mess with the running loop at all.
+    ##
+    ## /config saveall
+    @configGroup.command(name="saveall", description="Saves all configurations currently in memory to disk.")
+    async def saveAll(self, ctx):
+        try:
+            msg = await ctx.respond("Preparing to save data, please do not remove MEMORY CARD™ for PLAYSTATION®2...")
+            if (not astralStorage.isCallerOwner(ctx.author)):
+                await msg.edit(content="You don't have permission to do that.")
+            
+            astralStorage.saveConfigsToDisk()
+            await msg.edit(content="Saved to MEMORY CARD™ for PLAYSTATION®2 in slot 1.")
+        except Exception as e:
+            content = "Something went wrong while running that command."
+            if astralStorage.getGlobalBool("astral", "debug"):
+                print("[command] roletest failed: {e}")
+                content += f"\n{e}"
+            await msg.edit(content=content)
+
+    # Global group commands
+    globalGroup = configGroup.create_subgroup("global", "Conigures bot-wide settings (owner-only)")
+    
+    ## Add or remove owners of the bot. These members can run owner-only commands.
+    ## If there are no pre-existing owners, the first user to bepassed through this command will be given
+    ## an "owner" title. They will need to be the one to add other owners in the future.
+    ## 
+    ## /config global owner {add/remove} {user}
+    @globalGroup.command(name="owner",description=f"Add an owner to the owner list (owner-only)")
+    @option("operation",type=str,choices=[OptionChoice("Add role to allowlist", "add"), OptionChoice("Remove role from allowlist", "remove")],description="What should be done here?",required=True)
+    @option("user", type=discord.Member, description="The user to add as an owner", required=True)
+    async def addOwner(self, ctx, operation: str, user: discord.Member):
+        try:
+            msg = await ctx.respond(f"Preparing to add {user.mention} as an owner...")
+            owners = astralStorage.getGlobalIntList("astral", "owners")
+            if ctx.author.id not in owners and len(owners) > 0:
+                await msg.edit(content="You don't have permission to do that.")
+                return
+            
+            if user.id in owners and operation == "add":
+                if ctx.author.id == user.id:
+                    await msg.edit(content=f"You already own me.")
+                    return 
+                await msg.edit(content=f"***{user.mention}*** already owns me.")
+                return
+            
+            if user.id not in owners and operation == "remove":
+                await msg.edit(content=f"***{user.mention}*** doesn't already own me.")
+                return
+            
+            owners.append(user.id)
+            astralStorage.setGlobalList("astral", "owners", owners)
+            await msg.edit(content=f"Added ***{user.mention}*** as an owner for {astralStorage.getGlobalStr("astral", "name")}.")
+        except Exception as e:
+            msg = "Something went wrong while running that command."
+            if astralStorage.getGlobalBool("debug"):
+                print("[command] addOwner failed: {e}")
+                msg += f"\n{e}"
+            await msg.edit(content=msg)
+
+    @globalGroup.command(name="escpos",description=f"Configure ESC/POS settings (owner-only)")
+    @option("ip",type=str,description="The IP address of the ESC/POS printer to connect to.",required=False)
+    @option("port",type=int,description="The port of the ESC/POS printer to connect to.",required=False)
+    @option("profile",type=str,description="The profile of the ESC/POS printer, usually the model name.",required=False)
+    @option("enable_multitone",type=bool,description="Should multitone printing support be available to users?",required=False)
+    @option("verbosity",type=bool,description="Should messages update with each action in the ESC/POS pipeline?",required=False)
+    async def configureEscpos(self, ctx, ip: str = None, port: int = None, profile: str = None, multitone: bool = None, verbosity: bool = None):
+        try:
+            msg = await ctx.respond("Configuring ESC/POS functionality...")
+            if (not astralStorage.isCallerOwner(ctx.author)):
+                await msg.edit(content="You don't have permission to do that.")
+            
+            content = ""
+            if ip is not None:
+                val = astralStorage.getGlobalStr("escpos", "ip")
+                if val is not None and ip == val:
+                    content += f"IP address remains set to {ip}\n"
+                else:
+                    astralStorage.setGlobalStr("escpos", "ip", ip)
+                    content += f"IP address has been set to {ip}\n"
+            if port is not None:
+                val = astralStorage.getGlobalStr("escpos", "port")
+                if val is not None and port == val:
+                    content += f"Port remains set to {ip}\n"
+                else:
+                    astralStorage.setGlobalInt("escpos", "port", port)
+                    content += f"Port has been set to {port}\n"
+            if profile is not None:
+                val = astralStorage.getGlobalStr("escpos", "profile")
+                if val is not None and profile == val:
+                    content += f"Profile remains set to {ip}\n"
+                else:
+                    astralStorage.setGlobalStr("escpos", "profile", profile)
+                    content += f"Profile has been set to {profile}\n"
+            if multitone is not None:
+                val = astralStorage.getGlobalStr("escpos", "multitone")
+                if val is not None and multitone == val:
+                    content += f"Multitone remains {"enabled" if multitone else "disabled"}\n"
+                else:
+                    astralStorage.setGlobalBool("escpos", "multitone", multitone)
+                    content += f"Multitone is {"enabled" if multitone else "disabled"}\n"
+            if verbosity is not None:
+                val = astralStorage.getGlobalStr("escpos", "verbosity")
+                if val is not None and verbosity == val:
+                    content += f"Discord verbosity remains set to {ip}\n"
+                else:
+                    astralStorage.setGlobalBool("escpos", "verbosity", verbosity)
+                    content += f"Discord verbosity {"enabled" if multitone else "disabled"}\n"
+            await msg.edit(content=f"{content}\nYour changes have been saved.")
+        except Exception as e:
+            content = "Something went wrong while running that command."
+            if astralStorage.getGlobalBool("astral", "debug"):
+                print("[command] roletest failed: {e}")
+                content += f"\n{e}"
+            await msg.edit(content=content)
+
+    # Commands related to the management of ESC/POS functionality
+    escposGroup = configGroup.create_subgroup("escpos", "Configure settings related to printing on an ESC/POS printer")
+
+    ## (Per-server) Configures the role(s) that are allowed to use ESC/POS commands that cause actual printing.
+    ## This can only be configured by the owners of the bot.
+    ##
+    ## /config escpos role {add/remove} {role}
+    @escposGroup.command(name="role",description="Configure what roles can and cannot access ESC/POS functionality.")
+    @option("operation",type=str,choices=[OptionChoice("Add role to allowlist", "add"), OptionChoice("Remove role from allowlist", "remove")],description="What should be done here?",required=False)
+    @option("role", type=discord.Role, description="The role to act upon", required=False)
+    async def escposRolesFromServer(self, ctx, operation: str = None, role: discord.Role = None): 
+        try:
+            roles = astralStorage.getServerIntList(ctx.guild.id, "allowedroles", "escpos")
+            if roles is None: roles = []
+            if operation is None and role is None:
+                msg = await ctx.respond("Getting ESC/POS roles...")
+                
+                content = "The following roles can interact with the printer: "
+                rolesList = []
+                for roleid in roles:
+                    roleToMention = ctx.guild.get_role(roleid)
+                    if roleToMention: 
+                        rolesList.append(roleToMention.mention)
+
+                content += ", ".join(rolesList)
+                await msg.edit(content=content)
+                return
+            
+            if operation is None:
+                await ctx.respond("You need to supply what to do with the role.")
+                return
+            
+            if role is None:
+                await ctx.respond(f"You need to supply the role to {operation}.")
+                return
+
+
+            msg = await ctx.respond(f"Preparing to {operation} {role.mention} to escpos roles...")
+            if (not astralStorage.isCallerOwner(ctx.author)):
+                await msg.edit(content="You don't have permission to do that.")
+            
+            if role.id in roles and operation == "add":
+                await msg.edit(content=f"Users with ***{role.mention}*** can already interact with the ESC/POS printer.")
+                return
+            
+            if role.id not in roles and operation == "remove":
+                await msg.edit(content=f"Users with ***{role.mention}*** are already unable with the ESC/POS printer.")
+                return
+
+            if operation == "add":    roles.append(role.id)
+            if operation == "remove": roles.remove(role.id)
+            astralStorage.setServerList(ctx.guild.id, "allowedroles", "escpos", roles)
+            await msg.edit(content=f"Users with ***{role.mention}*** can {"now" if operation == "add" else "no longer"} interact with the ESC/POS printer.")
+        except Exception as e:
+            content = "Something went wrong while running that command."
+            if astralStorage.getGlobalBool("astral", "debug"):
+                print("[command] escposRolesFromServer failed: {e}")
+                content += f"\n{e}"
+            await msg.edit(content=content)
+
+    # Cartel commands
+    cartelGroup = configGroup.create_subgroup("cartel", "Configure settings related to the cartel")
+
+def setup(bot): # this is called by Pycord to setup the cog
+    bot.add_cog(config(bot)) # add the cog to the bot

--- a/cogs/config.py
+++ b/cogs/config.py
@@ -5,6 +5,7 @@ from discord import option
 from discord.commands import SlashCommandGroup, OptionChoice
 from discord.ext import commands
 from support.storage import astral_storage
+from support.autosave import _update as update_autosave
 
 class config(commands.Cog):
     def __init__(self, bot):
@@ -72,6 +73,22 @@ class config(commands.Cog):
                 print("[command] addOwner failed: {e}")
                 msg += f"\n{e}"
             await msg.edit(content=msg)
+
+    @globalGroup.command(name="saveinterval",description=f"Change the auto-save interval (owner-only)")
+    @option("seconds", type=int,description="The amount of time (in seconds) to automatically save all configurations to disk", required=True)
+    async def configureSaveInterval(self, ctx, secs):
+        try:
+            msg = await ctx.respond("Configuring auto-save interval...")
+            astral_storage.set_global_int("astral", "save_interval", secs)
+            update_autosave()
+            await msg.edit(content=f"Auto-save interval updated to {secs} seconds.")
+        except Exception as e:
+            content = "Something went wrong while running that command."
+            if astral_storage.get_global_bool("astral", "debug"):
+                print(f"[command] roletest failed: {e}")
+                content += f"\n{e}"
+            await msg.edit(content=content)
+
 
     @globalGroup.command(name="escpos",description=f"Configure ESC/POS settings (owner-only)")
     @option("ip",type=str,description="The IP address of the ESC/POS printer to connect to.",required=False)

--- a/cogs/escpos.py
+++ b/cogs/escpos.py
@@ -18,7 +18,7 @@ from support.storage import astralStorage
 class escpos(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.supported_pil_image_types = {ex for ex, f in Image.registered_extensions().items() if f in Image.OPEN}
+        self.supported_pil_image_types = tuple(ex for ex, f in Image.registered_extensions().items() if f in Image.OPEN)
 
         # Don't worry about the None here, it's set later when commands are run
         self.allowed_role_ids     = None 

--- a/cogs/escpos.py
+++ b/cogs/escpos.py
@@ -1,0 +1,287 @@
+import os
+import configparser
+from pathlib import Path
+from io import BytesIO
+
+import requests
+import discord
+from discord.commands import SlashCommandGroup
+from discord.ext import commands
+from discord import option
+from escpos.printer import Network
+from PIL import Image
+from PIL import ImageEnhance
+
+from support.multitone import main as multitoneImage
+from support.storage import astralStorage
+
+class escpos(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.supported_pil_image_types = {ex for ex, f in Image.registered_extensions().items() if f in Image.OPEN}
+
+        # Don't worry about the None here, it's set later when commands are run
+        self.allowed_role_ids     = None 
+        self.verbosity_to_discord = astralStorage.getGlobalBool("escpos", "verbosity")
+        self.printer_ip           = astralStorage.getGlobalStr("escpos", "ip")
+        self.printer_port         = astralStorage.getGlobalInt("escpos", "port")
+        self.printer_profile      = astralStorage.getGlobalStr("escpos", "profile")
+        self.enable_multitone     = astralStorage.getGlobalBool("escpos", "multitone")
+
+        if None in [
+            self.verbosity_to_discord, 
+            self.printer_ip, 
+            self.printer_profile, 
+            self.enable_multitone
+        ]:
+            print("[escpos ] Couldn't find a required configuration option, check your configuration file!")
+            return
+        
+        msg  =  "[escpos ] Read configuration, seems to be valid! The configuration is:\n"
+        msg += f"[escpos ] - Discord: Allowed roles are {self.allowed_role_ids} and verbosity to discord is {self.verbosity_to_discord} \n"
+        msg += f"[escpos ] - Networking: IP is {self.printer_ip} and port is {self.printer_port}\n"
+        msg += f"[escpos ] - Printer: Profile is {self.printer_profile} and multitoning is {self.enable_multitone}"
+        print(msg)
+
+
+    def parse_paper_status(self, status):
+        print(f"[parse_paper_status] Received paper status: {status}")
+        if status == 0:
+            return "There is no paper"
+        elif status == 1:
+            return "The paper is almost out"
+        elif status == 2:
+            return "There is plenty of paper"
+        else:
+            return "Unknown Status"
+
+    def calculate_brightness(self, image):
+        greyscale_image = image.convert('L')
+        histogram = greyscale_image.histogram()
+        pixels = sum(histogram)
+        brightness = scale = len(histogram)
+
+        for index in range(0, scale):
+            ratio = histogram[index] / pixels
+            brightness += ratio * (-scale + index)
+
+        return 1 if brightness == 255 else brightness / scale
+
+    def calculate_brightness_enhancement(self, brightness, max_enhancement=5):
+        """
+        Calculate how much to brighten an image based on its current brightness.
+        
+        Args:
+            brightness: Float from 0.0 (dark) to 1.0 (bright)
+            max_enhancement: Maximum brightening factor to apply (default 2.0)
+        
+        Returns:
+            Float representing the enhancement multiplier (1.0 = no change)
+        """
+        return 1.0 + (1.0 - brightness) ** 3.9 * (max_enhancement - 1.0)
+
+    bot = SlashCommandGroup("escpos", "Various little commands of dubious utility")
+
+    @bot.command(name="print", description="Print a message on the printer (5 second cooldown)")
+    @commands.cooldown(1, 5, commands.BucketType.user) 
+    @option("texttoprint", description="The text you want to print (200 character limit)", required=True)
+    async def print_message(self, ctx, texttoprint: str):
+        await ctx.defer()
+        roles = astralStorage.getServerIntList(ctx.guild.id, "allowedroles", "escpos")
+        if roles is None:
+            print(f"[print] Server {ctx.guild.id} has not configured escpos functionality")
+            await ctx.respond("This server doesn't currently have the required ESC/POS settings configured.")
+        else: self.allowed_role_ids = roles
+
+        member = ctx.guild.get_member(ctx.author.id)
+        if not member or not any(role_id in [role.id for role in member.roles] for role_id in self.allowed_role_ids):
+            print(f"[print] User '{ctx.author.id}' does not have the required roles to use the print command")
+            await ctx.respond("You don't have the required role to use this command")
+            raise commands.CheckFailure
+        callerDisplayname = member.display_name
+        callerUsername = member.name
+
+        msg = await ctx.respond(f"Preparing to print your text")
+        print(f"[print] User '{callerDisplayname} ({callerUsername})' is printing message: {texttoprint}")
+        try:
+            if len(texttoprint) > 200:
+                raise ValueError("The text to print is too long. Please limit it to 200 characters")
+            
+            if self.verbosity_to_discord: await msg.edit("Connecting to the printer... (1/2)")
+            printer = Network(self.printer_ip, self.printer_port, profile=self.printer_profile)
+            printer.open()
+            if printer.paper_status() == 0:
+                printer.close()
+                raise Exception("There is no paper in the printer")
+            print("[print] Opened printer")
+            if self.verbosity_to_discord: await msg.edit("Connected, now printing your text... (2/2)")
+            printer.text(f"Message from '{callerDisplayname} ({callerUsername})':\n{texttoprint}\n")
+            printer.cut()
+            printer.close()
+            print("[print] Closed printer")
+        except Exception as e:
+            print(repr(e))
+            await msg.edit(f"An error occurred while trying to print: {repr(e)}")
+            return
+        await msg.edit(f"Message '{texttoprint}' printed successfully")
+
+    @bot.command(name="image", description="Print an image on the printer (15 second cooldown)")
+    @commands.cooldown(1, 15, commands.BucketType.user) 
+    @option("imagetoprint", type=discord.Attachment, description="The image you want to print", required=True)
+    @option("multitone", type=bool, description="Higher quality by using 8 shades of gray instead of 2", required=False)
+    async def print_image(self, ctx: discord.ApplicationContext, imagetoprint: discord.Attachment, multitone: bool = False):
+        await ctx.defer()
+        roles = astralStorage.getServerIntList(ctx.guild.id, "allowedroles", "escpos")
+        if roles is None:
+            print(f"[print] Server {ctx.guild.id} has not configured escpos functionality")
+            await ctx.respond("This server doesn't currently have the required ESC/POS settings configured.")
+            raise commands.CheckFailure
+        else: self.allowed_role_ids = roles
+        
+        member = ctx.guild.get_member(ctx.author.id)
+        if not member or not any(role_id in [role.id for role in member.roles] for role_id in self.allowed_role_ids):
+            print(f"[image] User '{ctx.author.id}' does not have the required roles to use the print command")
+            await ctx.respond("You don't have the required role to use this command")
+            raise commands.CheckFailure
+        callerDisplayname = member.display_name
+        callerUsername = member.name
+        imagename = imagetoprint.filename
+
+        msg = await ctx.respond(f"Preparing to print your image {imagename}")
+        print(f"[image] User '{callerDisplayname} ({callerUsername})' is printing an image {imagename}")
+
+        try:
+            if not imagename.lower().endswith(self.supported_pil_image_types):
+                raise ValueError(f"The file {imagename} is not an image. Supported types are: {(', '.join(self.supported_pil_image_types))}")
+            print(f"[image] File is of type {(', '.join(self.supported_pil_image_types))}")
+            
+            if self.verbosity_to_discord: await msg.edit("Downloading your image (1/4)")
+            print("[image] Downloading image")
+            remote_file = requests.get(imagetoprint.url)
+
+            image = Image.open(BytesIO(remote_file.content))
+            print("[image] Image opened")
+            # open image from file
+
+            if self.verbosity_to_discord: await msg.edit("Applying processing to your image (2/4)")
+            if not image.width < image.height:
+                print("[image] Image is wide, rotating to landscape")
+                image = image.rotate(270, expand=True)
+            image = image.convert("L")
+            #Acquire image, rotate and grayscale it
+
+            brightness = self.calculate_brightness(image)
+            print(f"[image] Calculated brightness: {brightness}")
+            brightness_enhancement = self.calculate_brightness_enhancement(brightness)
+            print(f"[image] Calculated brightness enhancement: {brightness_enhancement}")
+            brightnessfilter = ImageEnhance.Brightness(image)
+            image = brightnessfilter.enhance(brightness_enhancement)
+            # Calculate brightness to apply and apply it
+        
+            contrastfilter = ImageEnhance.Contrast(image)
+            image = contrastfilter.enhance(0.8)
+            #screenshot = screenshot.quantize(colors=8)
+            # Reduce contrast a bit
+
+            image.thumbnail((512, 768), Image.Resampling.NEAREST)
+            # Resize to be max 512 wide and 768 tall
+            print("[image] Adjusted, grayscaled and resized image")
+
+            byteImage = BytesIO()
+            image.save(byteImage, "JPEG")
+            byteImage.seek(0)
+            discordFile = discord.File(fp=byteImage, filename=imagename, description="Image uploaded for printing")
+            print("[image] Created discord file object from processed image")
+
+            if multitone:
+                if not self.enable_multitone:
+                    raise Exception("Multitoning is disabled in the configuration")
+                print("[image] Processing multitone")
+                contrastfilter = ImageEnhance.Contrast(image)
+                image = contrastfilter.enhance(0.7)
+                brightnessfilter = ImageEnhance.Brightness(image)
+                image = brightnessfilter.enhance(1.28)
+
+                tempBytes = BytesIO()
+                tempBytes = multitoneImage(image=image, output_file=None, output_image=None, num_lines=100, resize=None, sharpness=None, contrast=None, cut=None, speed=1, heads_energizing=1, loglevel="INFO")
+            
+            if self.verbosity_to_discord: await msg.edit("Connecting to the printer... (3/4)")
+            printer = Network(self.printer_ip, profile=self.printer_profile)
+            printer.open()
+            if printer.paper_status() == 0:
+                printer.close()
+                raise Exception("There is no paper in the printer")
+            print("[image] Opened printer")
+            try:
+                if self.verbosity_to_discord: await msg.edit("Connected, now printing your image... (4/4)")
+                printer.text(f"Image from '{callerDisplayname} ({callerUsername})':\n")
+                if multitone:
+                    print("[image] Printing multitone")
+                    printer._raw(tempBytes)
+                    printer.set_with_default()
+                else:
+                    print("[image] Printing normal")
+                    printer.image(image, center=True, impl='graphics')
+                
+                printer.cut()
+                printer.close()
+                print("[image] Closed printer")
+            except Exception as e:
+                printer.close()
+                raise e
+        except Exception as e:
+            print(repr(e))
+            await msg.edit(f"An error occurred while trying to print your image: {repr(e)}")
+            #await ctx.respond(f"An error occurred while trying to print image: {repr(e)}")
+            return
+        await msg.edit(f"Image {imagename} printed successfully", file=discordFile)
+
+    @bot.command(name="supportedimagetypes", description="Check what types of images are supported")
+    async def supported_image_types(self, ctx):
+        await ctx.defer()
+        member = ctx.guild.get_member(ctx.author.id)
+        callerDisplayname = member.display_name
+        callerUsername = member.name
+        try:
+            await ctx.respond(f"Hi {callerDisplayname}, image types supported right now are {(', '.join(self.supported_pil_image_types))}")
+        except Exception as e:
+            print(repr(e))
+            await ctx.respond(f"An error occurred while: {repr(e)}")
+            return
+
+    @bot.command(name="paperstatus", description="Check how much paper is left in the printer")
+    @commands.cooldown(1, 10, commands.BucketType.user) 
+    async def paper_status(self, ctx: discord.ApplicationContext):
+        await ctx.defer()
+        msg = await ctx.respond("Checking the paper status")
+        try:
+            if self.verbosity_to_discord: await msg.edit("Connecting to the printer... (1/1)")
+            printer = Network(self.printer_ip, self.printer_port, profile=self.printer_profile)
+            printer.open()
+            print("[paper_status] Opened printer")
+            paper_status = self.parse_paper_status(printer.paper_status())
+            printer.close()
+        except Exception as e:
+            print(repr(e))
+            await msg.edit(f"An error occurred while getting paper status: {repr(e)}")
+            return
+        await msg.edit(f"Paper Status: {paper_status}")
+
+    @bot.command(name="chat", description="Send a message to chat")
+    @option("texttoprint", description="The text you want to send (500 character limit)", required=True)
+    async def chat_message(self, ctx: discord.ApplicationContext, texttoprint: str):
+        await ctx.defer()
+        member = ctx.guild.get_member(ctx.author.id)
+        callerDisplayname = member.display_name
+        callerUsername = member.name
+        try:
+            if len(texttoprint) > 500:
+                raise ValueError("The text to print is too long. Please limit it to 500 characters")
+            await ctx.respond(f"{callerDisplayname}: '{texttoprint}'")
+        except Exception as e:
+            print(repr(e))
+            await ctx.respond(f"An error occurred while: {repr(e)}")
+            return
+
+def setup(bot): # this is called by Pycord to setup the cog
+    bot.add_cog(escpos(bot)) # add the cog to the bot

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -8,10 +8,9 @@ from discord import Option
 from support.storage import astralStorage
 
 #load basic bot info from disk
-storage = astralStorage
 botVersion = "1.0.5"
 botVersionDate = "September 25 2023"
-botName = storage.getGlobalOption("name")
+botName = astralStorage.getGlobalOption("name")
 
 class fun(commands.Cog):
     def __init__(self, bot):

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -1,20 +1,17 @@
 import discord
-import requests
-import dotenv
-import os
 import cpuinfo
 import secrets
 from uwuipy import uwuipy
-from requests.exceptions import HTTPError
 from discord.commands import SlashCommandGroup
 from discord.ext import commands
 from discord import Option
+from support.storage import astralStorage
 
 #load basic bot info from disk
-dotenv.load_dotenv()
+storage = astralStorage
 botVersion = "1.0.5"
 botVersionDate = "September 25 2023"
-botName = str(os.getenv("botName"))
+botName = storage.getGlobalOption("name")
 
 class fun(commands.Cog):
     def __init__(self, bot):
@@ -40,7 +37,7 @@ class fun(commands.Cog):
         match ctx.author.id:
             # no Eva
             case 626397784169381888:
-                await ctx.respond("shut up eva i'm going to have you up against a wall soon enough just Wait")
+                await ctx.respond("<@281503786986635265> pin this cow to a wall")
                 await ctx.send(":3")
                 return
             

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -10,7 +10,7 @@ from support.storage import astralStorage
 #load basic bot info from disk
 botVersion = "1.0.5"
 botVersionDate = "September 25 2023"
-botName = astralStorage.getGlobalOption("name")
+botName = astralStorage.getGlobalStr("astral", "name")
 
 class fun(commands.Cog):
     def __init__(self, bot):

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -5,12 +5,12 @@ from uwuipy import uwuipy
 from discord.commands import SlashCommandGroup
 from discord.ext import commands
 from discord import Option
-from support.storage import astralStorage
+from support.storage import astral_storage
 
 #load basic bot info from disk
 botVersion = "1.0.5"
 botVersionDate = "September 25 2023"
-botName = astralStorage.getGlobalStr("astral", "name")
+botName = astral_storage.get_global_str("astral", "name")
 
 class fun(commands.Cog):
     def __init__(self, bot):

--- a/storage/example.ini
+++ b/storage/example.ini
@@ -1,0 +1,6 @@
+[serverid]
+cartelowner = 1234567890
+
+[serverid.allowedroles]
+cartel = 1234567890
+escpos = 1234567890

--- a/storage/example.ini
+++ b/storage/example.ini
@@ -1,6 +1,48 @@
-[serverid]
-cartelowner = 1234567890
+;; To increase legibility (as the filename will be the server's ID),
+;; the friendly name is stored here for searching.
+name   = "Fruitycord"
 
-[serverid.allowedroles]
+;; Controls role requirement for various functionality.
+[allowedroles]
+;; Role used for managing cartel members and voting privileges.
+;; 
+;; /config cartel role <role ID>
 cartel = 1234567890
+;; Roles used for managing access to /escpos commands.
+;;
+;; /config escpos roles <role ID or IDs>
 escpos = 1234567890
+
+;; Controls user requirements for various functionality.
+;; Can be ignored if using roles.
+[allowedusers]
+;; Users that are allowed to use /escpos commands without
+;; the roles defined above.
+;;
+;; /config escpos users <user ID or IDs>
+escpos = 1234567890
+
+
+;; Controls cartel-specific functionality
+;; Currently used for internal state tracking
+[serverid.cartel]
+;; Current owner of the cartel channels. 
+;;
+;; Updated by voting for a new owner.
+owner  = 1234567890
+
+;; Controls cartel voting statistics.
+[serverid.cartel.voting]
+;; Whether or not a vote is in progress
+;;
+;; Updated by starting a vote for a new owner.
+inprog = false
+;; Time remaining for the current vote
+;;
+;; Updated by starting a vote for a new owner.
+time   = 0
+;; Number of votes for each user ID with at least one vote
+;;
+;; Updated by starting a vote for a new owner.
+votes_<userid> = 2
+votes_<userid2> = 4

--- a/support/autosave.py
+++ b/support/autosave.py
@@ -1,0 +1,22 @@
+from discord.ext import tasks
+from support.storage import astral_storage
+
+@tasks.loop(seconds=astral_storage.get_global_int("astral", "save_interval"))
+async def _autosave():
+    print("[storage] saving all configs to disk")
+    try:
+        astral_storage.save_configs_to_disk()
+        print(f"[storage] saved. waiting another {astral_storage.get_global_int('astral', 'save_interval')} seconds.")
+    except Exception as e:
+        print(e)
+
+
+def _start():
+    if not _autosave.is_running():
+        _autosave.start()
+
+
+def _update():
+    new_seconds = astral_storage.get_global_int("astral", "save_interval")
+    _autosave.change_interval(seconds=new_seconds)
+    print(f"[storage] autosave interval updated to {new_seconds}s")

--- a/support/error.py
+++ b/support/error.py
@@ -1,0 +1,52 @@
+from enum import Enum
+
+class _astral_error_mixin(Enum):
+    """
+    Small class used internally to provide extra properties for the error Enum.
+
+    Don't use this.
+    """
+    def __new__(cls, critical, message): 
+        obj = object.__new__(cls) 
+        obj._value_ = message 
+        obj.critical = critical 
+        return obj
+
+class astral_error:
+    """
+    Enum with sub-enums that define common errors used throughout astral's codebase.
+
+    Organized as such:
+    - Global, critical errors
+    - Server, critical errors
+    - Global, non-critical errors
+    - Server, non-critical errors
+
+    Critical errors should always be dealt with properly. Since these aren't Exceptions, you don't
+    always need to catch them as such - just cancelling the current task is fine in those cases.
+    Non-critical errors can safely be continued on, as long as you provide defaults in code.
+    """
+    class bot(_astral_error_mixin):
+        """
+        Common errors tied to bot initialization or other general bot-wide faults.
+        """
+        undef_token            = (True,  "Token not defined")
+
+    class escpos(_astral_error_mixin):
+        """
+        Common errors tied to the ESC/POS cog.
+        """
+        undef_ip               = (True,  "ESC/POS IP address not defined")
+        undef_profile          = (True,  "ESC/POS profile not defined")
+
+        undef_server           = (True,  "ESC/POS current server not configured")
+
+        undef_port             = (False, "ESC/POS port not defined")
+        undef_verbosity        = (False, "ESC/POS verbosity enablement not defined")
+        undef_multitone        = (False, "ESC/POS multitone enablement not defined")
+
+class astral_exception(Exception):
+    def __init__(self, error_enum): 
+        super().__init__(error_enum.value) 
+        self.error = error_enum
+

--- a/support/multitone.py
+++ b/support/multitone.py
@@ -1,0 +1,204 @@
+## Bastardized from https://github.com/dalpil/epson-multi-tone, commit e7ed6c4
+##
+## This is their code with slight modification so I can use it as a function in escpos-printer bot.
+## Changes made include:
+## - Removing commandline argument support (click)
+## - Removing file open and writing in favor of passing in data and returning data
+## ThatStella7922
+
+import logging
+import logging.config
+import time
+
+import numpy as np
+
+try:
+    import numba
+except ImportError:
+    _has_numba = False
+else:
+    _has_numba = True
+
+from PIL import Image, ImageEnhance
+
+
+def dither(original, diff_map, serpentine, palette):
+    input = original.copy()
+    output = np.zeros_like(input)
+
+    direction = 1
+    height, width = input.shape
+
+    for y in range(height):
+        for x in range(0, width, direction) if direction > 0 else range(width - 1, -1, direction):
+            # Do not dither black or white
+            if original[y, x] == 0 or original[y, x] == 255:
+                output[y, x] = original[y, x]
+                continue 
+
+            old_pixel = input[y, x]
+            new_pixel = palette[np.argmin(np.abs(palette - old_pixel))]
+            quantization_error = old_pixel - new_pixel
+            output[y, x] = new_pixel
+
+            for dx, dy, diffusion_coefficient in diff_map:
+                # Reverse the kernel if we are going right to left
+                if direction < 0:
+                    dx *= -1
+
+                xn, yn = x + dx, y + dy
+
+                if (0 <= xn < width) and (0 <= yn < height):
+                    input[yn, xn] = max(0, min(255, input[yn, xn] + round(quantization_error * diffusion_coefficient)))
+
+        if serpentine:
+            direction *= -1
+
+    return output
+
+if _has_numba:
+    dither = numba.njit(dither)
+
+#@click.argument('image', type=click.File(mode='rb'))
+def main(image, output_file, output_image, num_lines, resize, sharpness, contrast, cut, speed, heads_energizing, loglevel):
+    logging.basicConfig(level=loglevel, format='[%(asctime)s] %(levelname)s: %(message)s')
+    logging.getLogger('numba').setLevel('CRITICAL')
+    logging.getLogger('PIL').setLevel('CRITICAL')
+
+    log = logging.getLogger(__name__)
+
+    if image.mode == 'RGBA':
+        log.debug('Input image has transparency channel, setting all transparent pixels to white')
+        white_background = Image.new('RGBA', image.size, 'WHITE')
+        white_background.paste(image, mask=image)
+        image = white_background
+
+    # Resize the image if requested by the user, or if the image is wider than 512 pixels
+    if resize or image.width > 512:
+        ratio = (resize or 512) / image.width
+        image = image.resize((round(image.width * ratio), round(image.height * ratio)))
+        log.info(f'Resized image to {image.width}x{image.height}')
+
+    width = image.width
+    width_nbytes = (width + 8 - 1) // 8
+    height = image.height
+
+    # Apply image adjustments
+    image = image.convert('L')
+    if sharpness:
+        image = ImageEnhance.Sharpness(image)
+        image = image.enhance(sharpness)
+        log.info(f'Modified sharpness of image with factor {sharpness}')
+
+    if contrast:
+        image = ImageEnhance.Contrast(image)
+        image = image.enhance(contrast)
+        log.info(f'Modified contrast of image image with factor {contrast}')
+
+    dither_kernel = (
+        (1, 0, 0.5423),
+        (2, 0, 0.0533),
+
+        (-2, 1, 0.0246),
+        (-1, 1, 0.2191),
+        (0, 1, 0.4715),
+        (1, 1, -0.0023),
+        (2, 1, -0.1241),
+
+        (-2, 2, -0.0065),
+        (-1, 2, -0.0692),
+        (0, 2, 0.0168),
+        (1, 2, -0.0952),
+        (2, 2, -0.0304),
+    )
+
+    # This LUT was selected by printing a calibration sheet with each of the 16
+    # "colors". I then scanned the receipt and measured the average color of
+    # each calibration square, giving me a percentage between full black and
+    # full white. This percentage was then mapped to values between 0 and 255.
+    lut = {
+        0: 15,
+        9: 13,
+        45: 12,
+        54: 11,
+        98: 10,
+        107: 9,
+        157: 8,
+        210: 7,
+        242: 6,
+        251: 5,
+        255: 4
+    }
+
+    if _has_numba:
+        log.info('Dithering input image with JIT')
+    else:
+        log.info('Dithering input image without JIT, this might take a while...')
+
+    time_dither_start = time.time()
+    image = dither(np.array(image, dtype=np.int16), dither_kernel, True, np.array(list(lut.keys())))
+    image = Image.fromarray(np.uint8(image), 'L')
+    log.debug(f'Dithering finished, took {time.time() - time_dither_start} seconds')
+
+    if output_image:
+        image.save(output_image)
+        log.info(f'Wrote output image to {output_image}')
+
+    # Apply LUT
+    log.debug('Applying LUT to image')
+    image = [lut[p] for p in image.tobytes()]
+
+    log.debug('Generating ESC/POS commands')
+    output = bytearray()
+    #output = b''
+    output += bytes([0x1d, 0x28, 0x4b, 0x02, 0x00, 0x61, heads_energizing])
+    output += bytes([0x1d, 0x28, 0x4b, 0x02, 0x00, 0x32, speed])
+
+    # Large images needs to be sent to the printer in smaller slices to avoid banding while 
+    # printing. The height of these slices should preferably be less than half of 415 according
+    # to Epson. Maximum slice height will vary depending on the transport layer.
+    for slice_y_start in range(0, height, num_lines):
+        slice_y_end = min(slice_y_start + num_lines, height)
+        slice_height = slice_y_end - slice_y_start
+
+        slice = image[width * slice_y_start :
+                      width * slice_y_end]
+        
+        for color_index, color_code in enumerate(range(49, 53)):
+            bitplane = [0x00] * width_nbytes * slice_height
+
+            for index, pixel in enumerate(slice):
+                if pixel & (0b1000 >> color_index):
+                    bitplane[width_nbytes * (index // width) + (index % width) // 8] |= 1 << (7 - index % 8)
+
+            data = bytes([
+                0x1d, 0x38, 0x4c, # GS 8 L 
+
+                (10 + len(bitplane) >> 0)  & 0xff,
+                (10 + len(bitplane) >> 8)  & 0xff,
+                (10 + len(bitplane) >> 16) & 0xff,
+                (10 + len(bitplane) >> 24) & 0xff,
+
+                0x30, 0x70, # Function 112
+
+                52, # Multi-tone
+                1, 1, # No scaling
+
+                color_code,
+
+                (width >> 0) & 0xff, (width >> 8) & 0xff,
+                (slice_height >> 0) & 0xff, (slice_height >> 8) & 0xff,
+            ]) + bytes(bitplane)
+
+            output += data
+
+        output += bytes([0x1d, 0x28, 0x4c, 0x02, 0x00, 0x30, 2]) # Print stored data
+
+    if cut:
+        output += bytes([0x1d, 0x56, 65, 0]) # Feed and cut
+
+    #with open(output_file, 'wb') as file:
+    #    file.write(output)
+    #    log.info(f'Wrote output binary file to {output_file}')
+
+    return output

--- a/support/storage.py
+++ b/support/storage.py
@@ -1,0 +1,17 @@
+import configparser
+
+class astralStorage(object):
+    def __init__(self):
+        print("[storage] loading astral.ini")
+        self.globalConfig = configparser.ConfigParser(allow_no_value=True)
+        self.globalConfig.read("astral.ini")
+
+    def getGlobalOption(self, opt):
+        print(f"[storage] returning {opt}")
+        return self.globalConfig.get("astral", opt).strip()
+	
+    def setGlobalOption(self, opt, val):
+        print(f"[storage] setting {val} for {opt}")
+        self.globalConfig.set("astral", opt, val)
+
+astralStorage = astralStorage()

--- a/support/storage.py
+++ b/support/storage.py
@@ -1,7 +1,9 @@
 import configparser, os
+import inspect
 from asyncio import sleep 
-from discord import Member
-class astralStorage(object):
+from discord import Member, ApplicationContext
+from support.error import astral_error, astral_exception
+class astral_storage(object):
     # Object intended to hold individual server configurations
     # Don't access this directly; use the helpers.
     serverConfigs = {}
@@ -35,7 +37,7 @@ class astralStorage(object):
     
     # Save configurations to disk, used by the autosave loop 
     # but can be called manually when necessary.
-    def saveConfigsToDisk(self):
+    def save_configs_to_disk(self):
         try:
             with open("astral.ini", "w") as configfile:
                 print("[storage] saving astral.ini")
@@ -51,26 +53,26 @@ class astralStorage(object):
             raise Exception(f"[storage] Saving failed: {e}\n[storage] All data is EPHEMERAL until this issue is fixed!!!")
 
     # Getter wrappers for easy outputs
-    def getServerInt(self, server, section, opt) -> int:
-        val = self.getServerOption(server, section, opt)
+    def get_server_int(self, server, section, opt) -> int:
+        val = self.get_server_option(server, section, opt)
         return int(val) if val is not None else None
-    def getServerFloat(self, server, section, opt) -> float:   
-        val = self.getServerOption(server, section, opt)
+    def get_server_float(self, server, section, opt) -> float:   
+        val = self.get_server_option(server, section, opt)
         return float(val) if val is not None else None
-    def getServerStr(self, server, section, opt) -> str:  
-        val = self.getServerOption(server, section, opt)
+    def get_server_str(self, server, section, opt) -> str:  
+        val = self.get_server_option(server, section, opt)
         return val if val is not None else None
-    def getServerBool(self, server, section, opt) -> bool:     
-        val = self.getServerOption(server, section, opt)
+    def get_server_bool(self, server, section, opt) -> bool:     
+        val = self.get_server_option(server, section, opt)
         return bool(val) if val is not None else None
-    def getServerStrList(self, server, section, opt) -> list:  
-        val = self.getServerOption(server, section, opt)
+    def get_server_str_list(self, server, section, opt) -> list:  
+        val = self.get_server_option(server, section, opt)
         return list(map(str.strip, val.split(","))) if val is not None else None
-    def getServerIntList(self, server, section, opt) -> list:  
-        val = self.getServerOption(server, section, opt)
+    def get_server_int_list(self, server, section, opt) -> list:  
+        val = self.get_server_option(server, section, opt)
         return list(map(int, val.split(","))) if val is not None else None
     # Gets a raw string value from server specific .ini
-    def getServerOption(self, server, section, opt):
+    def get_server_option(self, server, section, opt):
         print(f"[storage] returning server {server} section {section} option {opt}")
         if server not in self.serverConfigs.keys():
             print("[storage] very bad state:")
@@ -95,13 +97,13 @@ class astralStorage(object):
         return val.strip() if val else None
 	
     # Setter wrappers for easy inputs
-    def setServerInt(self, server, section, opt, val):   self.setServerOption(server, section, opt, (str(val)))
-    def setServerFloat(self, server, section, opt, val): self.setServerOption(server, section, opt, (str(val)))
-    def setServerStr(self, server, section, opt, val):   self.setServerOption(server, section, opt, (str(val)))
-    def setServerBool(self, server, section, opt, val):  self.setServerOption(server, section, opt, "true" if val else "false")
-    def setServerList(self, server, section, opt, val):  self.setServerOption(server, section, opt, (str(",".join(map(str, val)))))
+    def set_server_int(self, server, section, opt, val):   self.set_server_option(server, section, opt, (str(val)))
+    def set_server_float(self, server, section, opt, val): self.set_server_option(server, section, opt, (str(val)))
+    def set_server_str(self, server, section, opt, val):   self.set_server_option(server, section, opt, (str(val)))
+    def set_server_bool(self, server, section, opt, val):  self.set_server_option(server, section, opt, "true" if val else "false")
+    def set_server_list(self, server, section, opt, val):  self.set_server_option(server, section, opt, (str(",".join(map(str, val)))))
     # Sets a raw string value in server specific .ini
-    def setServerOption(self, server, section, opt, val):
+    def set_server_option(self, server, section, opt, val):
         print(f"[storage] setting server {server} section {section} option {opt} = {val}")
 
         # If it's not here, we need to make it
@@ -119,26 +121,26 @@ class astralStorage(object):
         cfg.set(section, opt, val)
 
     # Getter wrappers for easy outputs
-    def getGlobalInt(self, section, opt) -> int:     
-        val = self.getGlobalOption(section, opt)
+    def get_global_int(self, section, opt) -> int:     
+        val = self.get_global_option(section, opt)
         return int(val) if val is not None else None
-    def getGlobalFloat(self, section, opt) -> float: 
-        val = self.getGlobalOption(section, opt)
+    def get_global_float(self, section, opt) -> float: 
+        val = self.get_global_option(section, opt)
         return float(val) if val is not None else None
-    def getGlobalStr(self, section, opt) -> str:     
-        val = self.getGlobalOption(section, opt)
+    def get_global_str(self, section, opt) -> str:     
+        val = self.get_global_option(section, opt)
         return val if val is not None else None
-    def getGlobalBool(self, section, opt) -> bool:   
-        val = self.getGlobalOption(section, opt)
+    def get_global_bool(self, section, opt) -> bool:   
+        val = self.get_global_option(section, opt)
         return bool(val) if val is not None else None
-    def getGlobalStrList(self, section, opt) -> list:  
-        val = self.getGlobalOption(section, opt)
+    def get_global_str_list(self, section, opt) -> list:  
+        val = self.get_global_option(section, opt)
         return list(map(str.strip, val.split(","))) if val is not None else None
-    def getGlobalIntList(self, section, opt) -> list:   
-        val = self.getGlobalOption(section, opt)
+    def get_global_int_list(self, section, opt) -> list:   
+        val = self.get_global_option(section, opt)
         return list(map(int, val.split(","))) if val is not None else None
     # Gets a raw string value from astral.ini
-    def getGlobalOption(self, section, opt):
+    def get_global_option(self, section, opt):
         print(f"[storage] returning global section {section} option {opt}")
         cfg = self.globalConfig
 
@@ -153,23 +155,23 @@ class astralStorage(object):
         return val.strip() if val else None
 	
     # Setter wrappers for easy inputs
-    def setGlobalInt(self, section, opt, val):   self.setGlobalOption(section, opt, (str(val)))
-    def setGlobalFloat(self, section, opt, val): self.setGlobalOption(section, opt, (str(val)))
-    def setGlobalStr(self, section, opt, val):   self.setGlobalOption(section, opt, (str(val)))
-    def setGlobalBool(self, section, opt, val):  self.setGlobalOption(section, opt, "true" if val else "false")
-    def setGlobalList(self, section, opt, val):  self.setGlobalOption(section, opt, (str(",".join(map(str, val)))))
+    def set_global_int(self, section, opt, val):   self.set_global_option(section, opt, (str(val)))
+    def set_global_float(self, section, opt, val): self.set_global_option(section, opt, (str(val)))
+    def set_global_str(self, section, opt, val):   self.set_global_option(section, opt, (str(val)))
+    def set_global_bool(self, section, opt, val):  self.set_global_option(section, opt, "true" if val else "false")
+    def set_global_list(self, section, opt, val):  self.set_global_option(section, opt, (str(",".join(map(str, val)))))
     # Sets a raw string value in astral.ini
-    def setGlobalOption(self, section, opt, val):
+    def set_global_option(self, section, opt, val):
         print(f"[storage] setting {val} for global section {section} option {opt}")
         self.globalConfig.set(section, opt, val)
     
     # Checks whether or not the passed int is in the owners list.
-    def isCallerOwner(self, user: Member) -> bool:
+    def is_caller_owner(self, user: Member) -> bool:
         # Disable the ability to run all owner-only commands by default.
         # This is overriden manually by config.py's addOwner.
-        return self.isCallerEntitledFor(user, False, astralStorage.getGlobalIntList("astral", "owners"))
+        return self.is_caller_entitled_for(user, False, astral_storage.get_global_int_list("astral", "owners"))
     
-    def isCallerEntitledFor(self, user: Member, shouldCheckRoles: bool, array: list = None) -> bool:
+    def is_caller_entitled_for(self, user: Member, shouldCheckRoles: bool, array: list = None) -> bool:
         if array is None:   return False
         if len(array) == 0: return False
         if shouldCheckRoles:
@@ -177,8 +179,22 @@ class astralStorage(object):
         else:
             return user.id in array
 
+    def issue_with_configuration_present(self, env, error_array: list, ctx: ApplicationContext = None) -> astral_error:
+        errors = []
+        for err, var, getter, default in error_array:
+            match len(inspect.signature(getter).parameters):
+                case 0: value = getter()
+                case 1: value = getter(ctx)
+            setattr(env, var, value)
+            if value is None: 
+                if err.critical: 
+                    errors.append(err)
+                
+                print(f"[storage] [verify] {err.value}")
+                if default is not None:
+                    print(f"[storage] [verify] Falling back to default value")
+                    setattr(env, var, default)
+        
+        return errors if len(errors) > 0 else None
 
-
-    
-
-astralStorage = astralStorage()
+astral_storage = astral_storage()

--- a/support/storage.py
+++ b/support/storage.py
@@ -1,17 +1,184 @@
-import configparser
-
+import configparser, os
+from asyncio import sleep 
+from discord import Member
 class astralStorage(object):
+    # Object intended to hold individual server configurations
+    # Don't access this directly; use the helpers.
+    serverConfigs = {}
+
+    # Initializer
     def __init__(self):
+        # Being a little lenient here since we can assume defaults elsewhere
         print("[storage] loading astral.ini")
         self.globalConfig = configparser.ConfigParser(allow_no_value=True)
-        self.globalConfig.read("astral.ini")
 
-    def getGlobalOption(self, opt):
-        print(f"[storage] returning {opt}")
-        return self.globalConfig.get("astral", opt).strip()
+        # ...although if the file fails to load, we have a bigger issue.
+        # Python will report the problem on its own though.
+        if open("astral.ini", "r"):
+            self.globalConfig.read("astral.ini")
+
+        # Iterate through the files in the storage directory that end in
+        # .ini, and load them into the serverConfigs dictionary.
+        for filename in os.listdir("storage"):
+            if filename.endswith(".ini"):
+                if "example" in filename:
+                    continue
+                
+                server_id = int(filename[:-4])
+
+                print(f"[storage] loading {filename}")
+                parser = configparser.ConfigParser()
+                parser.read(os.path.join("storage", filename))
+
+                self.serverConfigs[server_id] = parser
+                print(self.serverConfigs)
+    
+    # Save configurations to disk, used by the autosave loop 
+    # but can be called manually when necessary.
+    def saveConfigsToDisk(self):
+        try:
+            with open("astral.ini", "w") as configfile:
+                print("[storage] saving astral.ini")
+                self.globalConfig.write(configfile)
+            for server in self.serverConfigs:
+                filename = f"storage/{server}.ini"
+                with open(filename, "w") as serverfile:
+                    print(f"[storage] saving {serverfile.name}")
+                    self.serverConfigs[server].write(serverfile)
+        # This time Python won't do the Except-ing for us. Whatever is 
+        # calling this function should catch this!
+        except Exception as e:
+            raise Exception(f"[storage] Saving failed: {e}\n[storage] All data is EPHEMERAL until this issue is fixed!!!")
+
+    # Getter wrappers for easy outputs
+    def getServerInt(self, server, section, opt) -> int:
+        val = self.getServerOption(server, section, opt)
+        return int(val) if val is not None else None
+    def getServerFloat(self, server, section, opt) -> float:   
+        val = self.getServerOption(server, section, opt)
+        return float(val) if val is not None else None
+    def getServerStr(self, server, section, opt) -> str:  
+        val = self.getServerOption(server, section, opt)
+        return val if val is not None else None
+    def getServerBool(self, server, section, opt) -> bool:     
+        val = self.getServerOption(server, section, opt)
+        return bool(val) if val is not None else None
+    def getServerStrList(self, server, section, opt) -> list:  
+        val = self.getServerOption(server, section, opt)
+        return list(map(str.strip, val.split(","))) if val is not None else None
+    def getServerIntList(self, server, section, opt) -> list:  
+        val = self.getServerOption(server, section, opt)
+        return list(map(int, val.split(","))) if val is not None else None
+    # Gets a raw string value from server specific .ini
+    def getServerOption(self, server, section, opt):
+        print(f"[storage] returning server {server} section {section} option {opt}")
+        if server not in self.serverConfigs.keys():
+            print("[storage] very bad state:")
+            print(f"[storage] {server} not in serverconfigs")
+            print(self.serverConfigs)
+        
+        cfg = self.serverConfigs.get(server)
+
+        if cfg is None:
+            print(f"[storage] wasn't able to find an existing configuration for {server}, making a new one")
+            cfg = configparser.ConfigParser(allow_no_value=True)
+            self.serverConfigs[server] = cfg
+
+        if not cfg.has_section(section):
+            print(f"[storage] wasn't able to find {section} in {server} config, making a new one")
+            cfg.add_section(section)
+            return None
+
+
+        # Safe: fallback applies to missing option
+        val = cfg.get(section, opt, fallback=None)
+        return val.strip() if val else None
 	
-    def setGlobalOption(self, opt, val):
-        print(f"[storage] setting {val} for {opt}")
-        self.globalConfig.set("astral", opt, val)
+    # Setter wrappers for easy inputs
+    def setServerInt(self, server, section, opt, val):   self.setServerOption(server, section, opt, (str(val)))
+    def setServerFloat(self, server, section, opt, val): self.setServerOption(server, section, opt, (str(val)))
+    def setServerStr(self, server, section, opt, val):   self.setServerOption(server, section, opt, (str(val)))
+    def setServerBool(self, server, section, opt, val):  self.setServerOption(server, section, opt, "true" if val else "false")
+    def setServerList(self, server, section, opt, val):  self.setServerOption(server, section, opt, (str(",".join(map(str, val)))))
+    # Sets a raw string value in server specific .ini
+    def setServerOption(self, server, section, opt, val):
+        print(f"[storage] setting server {server} section {section} option {opt} = {val}")
+
+        # If it's not here, we need to make it
+        cfg = self.serverConfigs.get(server)
+        if cfg is None:
+            print(f"[storage] server {server} is new, creating blank config")
+            cfg = configparser.ConfigParser(allow_no_value=True)
+            self.serverConfigs[server] = cfg
+
+        # Same as above
+        if not cfg.has_section(section):
+            print(f"[storage] section [{section}] missing, creating it")
+            cfg.add_section(section)
+
+        cfg.set(section, opt, val)
+
+    # Getter wrappers for easy outputs
+    def getGlobalInt(self, section, opt) -> int:     
+        val = self.getGlobalOption(section, opt)
+        return int(val) if val is not None else None
+    def getGlobalFloat(self, section, opt) -> float: 
+        val = self.getGlobalOption(section, opt)
+        return float(val) if val is not None else None
+    def getGlobalStr(self, section, opt) -> str:     
+        val = self.getGlobalOption(section, opt)
+        return val if val is not None else None
+    def getGlobalBool(self, section, opt) -> bool:   
+        val = self.getGlobalOption(section, opt)
+        return bool(val) if val is not None else None
+    def getGlobalStrList(self, section, opt) -> list:  
+        val = self.getGlobalOption(section, opt)
+        return list(map(str.strip, val.split(","))) if val is not None else None
+    def getGlobalIntList(self, section, opt) -> list:   
+        val = self.getGlobalOption(section, opt)
+        return list(map(int, val.split(","))) if val is not None else None
+    # Gets a raw string value from astral.ini
+    def getGlobalOption(self, section, opt):
+        print(f"[storage] returning global section {section} option {opt}")
+        cfg = self.globalConfig
+
+        if cfg is None:
+            raise Exception("[storage] Can't access global config, this is fatal!!!")
+
+        if not cfg.has_section(section):
+            cfg.add_section(section)
+            return None
+
+        val = cfg.get(section, opt, fallback=None)
+        return val.strip() if val else None
+	
+    # Setter wrappers for easy inputs
+    def setGlobalInt(self, section, opt, val):   self.setGlobalOption(section, opt, (str(val)))
+    def setGlobalFloat(self, section, opt, val): self.setGlobalOption(section, opt, (str(val)))
+    def setGlobalStr(self, section, opt, val):   self.setGlobalOption(section, opt, (str(val)))
+    def setGlobalBool(self, section, opt, val):  self.setGlobalOption(section, opt, "true" if val else "false")
+    def setGlobalList(self, section, opt, val):  self.setGlobalOption(section, opt, (str(",".join(map(str, val)))))
+    # Sets a raw string value in astral.ini
+    def setGlobalOption(self, section, opt, val):
+        print(f"[storage] setting {val} for global section {section} option {opt}")
+        self.globalConfig.set(section, opt, val)
+    
+    # Checks whether or not the passed int is in the owners list.
+    def isCallerOwner(self, user: Member) -> bool:
+        # Disable the ability to run all owner-only commands by default.
+        # This is overriden manually by config.py's addOwner.
+        return self.isCallerEntitledFor(user, False, astralStorage.getGlobalIntList("astral", "owners"))
+    
+    def isCallerEntitledFor(self, user: Member, shouldCheckRoles: bool, array: list = None) -> bool:
+        if array is None:   return False
+        if len(array) == 0: return False
+        if shouldCheckRoles:
+            return any(role_id in [role.id for role in user.roles] for role_id in array)
+        else:
+            return user.id in array
+
+
+
+    
 
 astralStorage = astralStorage()


### PR DESCRIPTION
WIP

# Configuration

Uses `configparser` and `*.ini` in the `storage/` directory (as well as `astral.ini` in the root`) to enable custom configurations per-server.

Introduces the `support/` directory for any "support" modules, and the `storage.py` module with `astralStorage` that can be used like:

```py
from support.storage import astralStorage
```

You can use one of the various shorthands in the module for easily parsing output of configuration files.

# ESC/POS support
Ported `escpos-printer-bot` to `cogs/escpos.py`, has the same syntax and everything.

Requires being configured using `/config global escpos` and `/config escpos` in order to work.
- As of writing, there is not much handling for this setup. You will probably break the cog if the former is not set up properly.